### PR TITLE
Use shorter default format

### DIFF
--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -54,7 +54,7 @@ class ZNotice(object):
         self.recipient = None
         self.sender = None
         self.opcode = None
-        self.format = "Class $class, Instance $instance:\nTo: @bold($recipient) at $time $date\nFrom: @bold{$1 <$sender>}\n\n$2"
+        self.format = "http://zephyr.1ts.org/wiki/df"
         self.other_fields = []
         self.fields = []
 


### PR DESCRIPTION
This may have practical advantages when the zephyr header is otherwise quite
long. It should have negligible functional impact, since current clients mostly
ignore the field (paying attention to it is a security risk). The particular
default format this uses is a link to a page that will explaining (for any
clients that _do_ show it) why they're seeing it and why that's bad, and is the
same format used by barnowl and some other clients.
