### PR TITLE
Fix memory leak on receive path.

### DIFF
--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -220,13 +220,16 @@ def receive(block=False):
     errno = ZReceiveNotice(&notice, &sender)
     __error(errno)
 
-    if ZCheckAuthentication(&notice, &sender) == ZAUTH_YES:
-        notice.z_auth = 1
-    else:
-        notice.z_auth = 0
+    try:
+        if ZCheckAuthentication(&notice, &sender) == ZAUTH_YES:
+            notice.z_auth = 1
+        else:
+            notice.z_auth = 0
 
-    p_notice = ZNotice()
-    _ZNotice_c2p(&notice, p_notice)
+        p_notice = ZNotice()
+        _ZNotice_c2p(&notice, p_notice)
+    finally:
+        ZFreeNotice(&notice)
     return p_notice
 
 def sender():


### PR DESCRIPTION
receive() attempts to avoid memory management by using a local
variable "notice" as the storage area for the Zephyr notice object.
However, one still needs to call ZFreeNotice on the object at the end,
to free notice->z_packet.
