### PR TITLE
Improve charset support

### DIFF
--- a/_zephyr.pxd
+++ b/_zephyr.pxd
@@ -94,6 +94,14 @@ cdef extern from "zephyr/zephyr.h":
     int ZGetSubscriptions(ZSubscription_t subslist[], int* nitems)
     int ZFlushSubscriptions()
 
+    # XXX: This should really be const char * (or const_char *) -- see
+    # <http://docs.cython.org/src/tutorial/strings.html#dealing-with-const>
+    # In Cython 0.12, Cython doesn't seem to support const_char at all, and
+    # in Cython 0.15, it doesn't seem to be able to handle converting a
+    # const_char * to a Python string. Once we're dealing with newer Cythons,
+    # this should probably change, though.
+    char *ZCharsetToString(unsigned short charset)
+
 cdef extern from "Python.h":
     object PyString_FromStringAndSize(char *, Py_ssize_t)
 

--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -58,6 +58,7 @@ class ZNotice(object):
         self.format = "http://zephyr.1ts.org/wiki/df"
         self.other_fields = []
         self.fields = []
+        self._charset = None
 
         for k, v in options.iteritems():
             setattr(self, k, v)
@@ -69,6 +70,10 @@ class ZNotice(object):
         self.fields = newmsg.split('\0')
 
     message = property(getmessage, setmessage)
+
+    @property
+    def charset(self):
+        return self._charset
 
     def send(self):
         cdef object_pool pool
@@ -114,6 +119,8 @@ cdef void _ZNotice_c2p(ZNotice_t * notice, object p_notice) except *:
         p_notice.message = None
     else:
         p_notice.message = PyString_FromStringAndSize(notice.z_message, notice.z_message_len)
+
+    p_notice._charset = ZCharsetToString(notice.z_charset)
 
 cdef void _ZNotice_p2c(object notice, ZNotice_t * c_notice, object_pool *pool) except *:
     memset(c_notice, 0, sizeof(ZNotice_t))


### PR DESCRIPTION
This includes improved support for charsets. The first commit sets the charset to UTF-8 when take a Unicode python string and convert it to UTF-8 for sending. (Binary python strings continue to get sent out as UNKNOWN.) The second adds a read-only `charset` attribute to incoming messages.
