### PR TITLE
_ZNotice_p2c: Declare type for charset

### DIFF
--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -144,6 +144,7 @@ cdef void _ZNotice_p2c(object notice, ZNotice_t * c_notice, object_pool *pool) e
     for i in range(c_notice.z_num_other_fields):
         c_notice.z_other_fields[i] = _string_p2c(pool, notice.other_fields[i])
 
+    cdef unsigned short charset
     if isinstance(notice.message, unicode):
         notice.encoded_message = notice.message.encode('utf-8')
         charset = ZCHARSET_UTF_8


### PR DESCRIPTION
This is needed since `_ZCharsets` isn’t a real type.  Fixes this build error:

```
_zephyr.c: In function ‘__pyx_f_7_zephyr__ZNotice_p2c’:
_zephyr.c:2913:19: error: storage size of ‘__pyx_v_charset’ isn’t known
   enum _ZCharsets __pyx_v_charset;
                   ^~~~~~~~~~~~~~~
```
