### PR TITLE
Python 3 support

### DIFF
--- a/_zephyr.pxd
+++ b/_zephyr.pxd
@@ -103,7 +103,7 @@ cdef extern from "zephyr/zephyr.h":
     char *ZCharsetToString(unsigned short charset)
 
 cdef extern from "Python.h":
-    object PyString_FromStringAndSize(char *, Py_ssize_t)
+    object PyBytes_FromStringAndSize(char *, Py_ssize_t)
 
 cdef extern from "com_err.h":
     char * error_message(int)

--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -118,7 +118,7 @@ cdef void _ZNotice_c2p(ZNotice_t * notice, object p_notice) except *:
     if notice.z_message is NULL:
         p_notice.message = None
     else:
-        p_notice.message = PyString_FromStringAndSize(notice.z_message, notice.z_message_len)
+        p_notice.message = PyBytes_FromStringAndSize(notice.z_message, notice.z_message_len)
 
     p_notice._charset = ZCharsetToString(notice.z_charset)
 

--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -187,24 +187,6 @@ def sub(cls, instance, recipient):
     errno = ZSubscribeTo(newsub, 1, 0)
     __error(errno)
 
-def subAll(lst):
-    cdef ZSubscription_t *newsubs
-    cdef unsigned int i
-
-    newsubs = <ZSubscription_t*>calloc(len(lst), sizeof(ZSubscription_t))
-    try:
-        for 0 <= i < len(lst):
-            newsubs[i].zsub_class = lst[i][0]
-            newsubs[i].zsub_classinst = lst[i][1]
-            newsubs[i].zsub_recipient = lst[i][2]
-
-        errno = ZSubscribeTo(newsubs, len(lst), 0)
-        __error(errno)
-    finally:
-        if newsubs:
-            free(newsubs);
-    pass
-
 def unsub(cls, instance, recipient):
     cdef ZSubscription_t delsub[1]
 

--- a/zephyr.py
+++ b/zephyr.py
@@ -1,9 +1,12 @@
 import _zephyr as _z
 import os
+import sys
 
 from _zephyr import receive, ZNotice
 
 __inited = False
+
+is_py3 = sys.version_info.major >= 3
 
 def init():
     global __inited
@@ -12,6 +15,9 @@ def init():
         _z.openPort()
         _z.cancelSubs()
         __inited = True
+
+def realm():
+    return _z.realm().decode('utf-8')
 
 class Subscriptions(set):
     """
@@ -29,7 +35,6 @@ class Subscriptions(set):
 
     def __del__(self):
         _z.cancelSubs()
-        super(Subscriptions, self).__del__()
 
     def _fixTuple(self, item):
         if len(item) != 3:
@@ -40,8 +45,11 @@ class Subscriptions(set):
             item[2] = item[2][1:]
 
         if '@' not in item[2]:
-            item[2] += '@%s' % _z.realm()
+            item[2] += '@%s' % realm()
 
+        if is_py3:
+            item = [bytes(i, "utf-8") for i in item]
+        print(item)
         return tuple(item)
 
     def add(self, item):

--- a/zephyr.py
+++ b/zephyr.py
@@ -33,7 +33,7 @@ class Subscriptions(set):
 
     def _fixTuple(self, item):
         if len(item) != 3:
-            raise TypeError, 'item is not a zephyr subscription tuple'
+            raise TypeError('item is not a zephyr subscription tuple')
 
         item = list(item)
         if item[2].startswith('*'):
@@ -58,7 +58,7 @@ class Subscriptions(set):
         item = self._fixTuple(item)
 
         if item not in self:
-            raise KeyError, item
+            raise KeyError(item)
 
         _z.unsub(*item)
 


### PR DESCRIPTION
It would be nice to have Python 3 support in python-zephyr. Here's a start, though I don't think it's complete (and I haven't gone to any effort to clean it up yet). (I'd have submitted this as an issue instead of a pull request, but issues appear disabled.)

One decision that probably deserves other opinions is whether the library should expose strings or bytes, and whether to accept bytes, strings, or both. My inclination is that the library should expose strings for ~everything, but I'm not sure how reasonable that is (and I don't have much experience with Python 3).