### PR TITLE
Fix some bugs in the timestamp conversion logic

### DIFF
--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -30,8 +30,8 @@ cdef void _ZUid_c2p(ZUnique_Id_t * uid, object p_uid) except *:
 
 cdef void _ZUid_p2c(object uid, ZUnique_Id_t * c_uid) except *:
     inet_aton(uid.address, &c_uid.zuid_addr)
-    c_uid.tv.tv_usec = int(uid.time)
-    c_uid.tv.tv_usec = int((uid.time - c_uid.tv.tv_usec) * 100000)
+    c_uid.tv.tv_sec = int(uid.time)
+    c_uid.tv.tv_usec = int((uid.time - c_uid.tv.tv_sec) * 100000)
 
 cdef char * _string_p2c(object_pool *pool, object string) except *:
     if string is None:

--- a/_zephyr.pyx
+++ b/_zephyr.pyx
@@ -4,6 +4,7 @@ import os
 import pwd
 import time
 import select
+import socket
 
 def __error(errno):
     if errno != 0:
@@ -26,12 +27,13 @@ class ZUid(object):
 
 cdef void _ZUid_c2p(ZUnique_Id_t * uid, object p_uid) except *:
     p_uid.address = inet_ntoa(uid.zuid_addr)
-    p_uid.time = uid.tv.tv_sec + (uid.tv.tv_usec / 100000.0)
+    p_uid.time = socket.ntohl(uid.tv.tv_sec) + (socket.ntohl(uid.tv.tv_usec) / 100000.0)
 
 cdef void _ZUid_p2c(object uid, ZUnique_Id_t * c_uid) except *:
     inet_aton(uid.address, &c_uid.zuid_addr)
-    c_uid.tv.tv_sec = int(uid.time)
-    c_uid.tv.tv_usec = int((uid.time - c_uid.tv.tv_sec) * 100000)
+    seconds = int(uid.time)
+    c_uid.tv.tv_sec = socket.htonl(seconds)
+    c_uid.tv.tv_usec = socket.htonl(int((uid.time - seconds) * 100000))
 
 cdef char * _string_p2c(object_pool *pool, object string) except *:
     if string is None:


### PR DESCRIPTION
1. In `_ZUid_p2c`, the `tv.tv_sec` was not populated. `tv.tv_usec` was populated twice.
2. libzephyr gives and expects timestamps in the `zuid` to be in network byte order.